### PR TITLE
Refactor/#33 redcard register migration

### DIFF
--- a/migration/build.gradle.kts
+++ b/migration/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("io.mockk:mockk:1.13.5") // MockK 추가
 
     // Thymeleaf
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")

--- a/migration/src/main/kotlin/com/redbox/domain/redcard/dto/RegisterRedcardRequest.kt
+++ b/migration/src/main/kotlin/com/redbox/domain/redcard/dto/RegisterRedcardRequest.kt
@@ -1,0 +1,16 @@
+package com.redbox.domain.redcard.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class RegisterRedcardRequest(
+    @field:NotBlank(message = "헌혈증 번호를 입력해주세요.")
+    val cardNumber: String,
+
+    @field:NotNull(message = "헌혈일자를 입력해주세요.")
+    val donationDate: LocalDate,
+
+    @field:NotBlank(message = "헌혈장소를 입력해주세요.")
+    val hospitalName: String
+)

--- a/migration/src/main/kotlin/com/redbox/domain/redcard/entity/OwnerType.kt
+++ b/migration/src/main/kotlin/com/redbox/domain/redcard/entity/OwnerType.kt
@@ -1,0 +1,6 @@
+package com.redbox.domain.redcard.entity
+
+enum class OwnerType {
+    USER,
+    REDBOX
+}

--- a/migration/src/main/kotlin/com/redbox/domain/redcard/entity/Redcard.kt
+++ b/migration/src/main/kotlin/com/redbox/domain/redcard/entity/Redcard.kt
@@ -1,0 +1,56 @@
+package com.redbox.domain.redcard.entity
+
+import com.redbox.global.entity.BaseEntity
+import jakarta.persistence.*
+import java.time.LocalDate
+
+@Entity
+@Table(name = "redcards")
+class Redcard(
+    @Column(name = "user_id", nullable = false)
+    var userId: Long,
+
+    @Column(nullable = false)
+    var donationDate: LocalDate,
+
+    @Column(nullable = false, unique = true)
+    var serialNumber: String,
+
+    @Column(nullable = false)
+    var hospitalName: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var redcardStatus: RedcardStatus,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var ownerType: OwnerType
+) : BaseEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "redcard_id")
+    var id: Long? = null
+        private set
+
+    // 헌혈증 소지자가 바뀔 때 사용하는 메서드
+    fun updateUser(userId: Long) {
+        this.userId = userId
+    }
+
+    // 헌혈증 상태를 변경하는 메서드
+    fun changeRedcardStatus(status: RedcardStatus) {
+        this.redcardStatus = status
+    }
+
+    // 헌혈증 소유자 타입 변경
+    fun changeOwnerType(ownerType: OwnerType) {
+        this.ownerType = ownerType
+    }
+
+    override fun toString(): String {
+        return "Redcard(userId=$userId, donationDate=$donationDate, serialNumber='$serialNumber', hospitalName='$hospitalName', redcardStatus=$redcardStatus, ownerType=$ownerType)"
+    }
+
+}

--- a/migration/src/main/kotlin/com/redbox/domain/redcard/entity/Redcard.kt
+++ b/migration/src/main/kotlin/com/redbox/domain/redcard/entity/Redcard.kt
@@ -49,6 +49,7 @@ class Redcard(
         this.ownerType = ownerType
     }
 
+    // TODO: 테스트를 위해 추가된 toString() 메서드 (나중에 상의 후 제거)
     override fun toString(): String {
         return "Redcard(userId=$userId, donationDate=$donationDate, serialNumber='$serialNumber', hospitalName='$hospitalName', redcardStatus=$redcardStatus, ownerType=$ownerType)"
     }

--- a/migration/src/main/kotlin/com/redbox/domain/redcard/entity/RedcardStatus.kt
+++ b/migration/src/main/kotlin/com/redbox/domain/redcard/entity/RedcardStatus.kt
@@ -1,0 +1,7 @@
+package com.redbox.domain.redcard.entity
+
+enum class RedcardStatus(val description: String) {
+    USED("사용 완료"),
+    AVAILABLE("사용 가능"),
+    PENDING("처리중")
+}

--- a/migration/src/main/kotlin/com/redbox/domain/redcard/exception/DuplicateSerialNumberException.kt
+++ b/migration/src/main/kotlin/com/redbox/domain/redcard/exception/DuplicateSerialNumberException.kt
@@ -1,0 +1,6 @@
+package com.redbox.domain.redcard.exception
+
+import com.redbox.global.exception.BusinessException
+import com.redbox.global.exception.ErrorCode
+
+class DuplicateSerialNumberException : BusinessException(ErrorCode.DUPLICATE_SERIAL_NUMBER)

--- a/migration/src/main/kotlin/com/redbox/domain/redcard/repository/RedcardRepository.kt
+++ b/migration/src/main/kotlin/com/redbox/domain/redcard/repository/RedcardRepository.kt
@@ -1,0 +1,9 @@
+package com.redbox.domain.redcard.repository
+
+import com.redbox.domain.redcard.entity.Redcard
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+interface RedcardRepository : JpaRepository<Redcard, Long> {
+    fun findBySerialNumber(serialNumber: String): Optional<Redcard>
+}

--- a/migration/src/main/kotlin/com/redbox/domain/redcard/service/RedcardService.kt
+++ b/migration/src/main/kotlin/com/redbox/domain/redcard/service/RedcardService.kt
@@ -1,0 +1,41 @@
+package com.redbox.domain.redcard.service
+
+import com.redbox.domain.redcard.dto.RegisterRedcardRequest
+import com.redbox.domain.redcard.entity.OwnerType
+import com.redbox.domain.redcard.entity.Redcard
+import com.redbox.domain.redcard.entity.RedcardStatus
+import com.redbox.domain.redcard.exception.DuplicateSerialNumberException
+import com.redbox.domain.redcard.repository.RedcardRepository
+// import com.redbox.domain.user.service.UserService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class RedcardService(
+    private val redcardRepository: RedcardRepository
+    // private val userService: UserService
+) {
+
+    @Transactional
+    fun registerRedCard(request: RegisterRedcardRequest) {
+
+        // 헌혈증 번호 중복 체크
+        val isDuplicate = redcardRepository.findBySerialNumber(request.cardNumber).isPresent
+        if (isDuplicate) {
+            throw DuplicateSerialNumberException()
+        }
+
+        // Redcard 생성
+        val redcard = Redcard(
+            // userId = userService.getCurrentUserId(),
+            userId = 0L, // TODO: UserService 추가 후 수정 필요
+            donationDate = request.donationDate,
+            serialNumber = request.cardNumber,
+            hospitalName = request.hospitalName,
+            redcardStatus = RedcardStatus.AVAILABLE,
+            ownerType = OwnerType.USER
+        )
+
+        redcardRepository.save(redcard)
+    }
+}

--- a/migration/src/test/kotlin/com/redbox/domain/redcard/service/RedcardServiceTest.kt
+++ b/migration/src/test/kotlin/com/redbox/domain/redcard/service/RedcardServiceTest.kt
@@ -1,0 +1,79 @@
+package com.redbox.domain.redcard.service
+
+import com.redbox.domain.redcard.dto.RegisterRedcardRequest
+import com.redbox.domain.redcard.entity.OwnerType
+import com.redbox.domain.redcard.entity.Redcard
+import com.redbox.domain.redcard.entity.RedcardStatus
+import com.redbox.domain.redcard.exception.DuplicateSerialNumberException
+import com.redbox.domain.redcard.repository.RedcardRepository
+import io.mockk.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+import java.util.*
+
+class RedcardServiceTest {
+
+    private lateinit var redcardRepository: RedcardRepository
+    private lateinit var redcardService: RedcardService
+    private val logger: Logger = LoggerFactory.getLogger(RedcardServiceTest::class.java)
+
+    @BeforeEach
+    fun setUp() {
+        redcardRepository = mockk()
+        redcardService = RedcardService(redcardRepository)
+    }
+
+    @Test
+    fun `should register redcard successfully`() {
+        // Given
+        val request = createRegisterRequest()
+        val redcard = createRedcard(request)
+
+        every { redcardRepository.findBySerialNumber(request.cardNumber) } returns Optional.empty()
+        every { redcardRepository.save(any()) } answers { firstArg() }
+
+        // When
+        redcardService.registerRedCard(request)
+
+        // Then
+        verify { redcardRepository.save(withArg { it.serialNumber == request.cardNumber }) }
+
+        // Log registered Redcard
+        logger.info("Successfully registered Redcard: $redcard")
+    }
+
+    @Test
+    fun `should throw exception when duplicate serial number exists`() {
+        // Given
+        val request = createRegisterRequest()
+
+        every { redcardRepository.findBySerialNumber(request.cardNumber) } returns Optional.of(mockk())
+
+        // When & Then
+        assertThrows<DuplicateSerialNumberException> {
+            redcardService.registerRedCard(request)
+        }
+
+        verify { redcardRepository.findBySerialNumber(request.cardNumber) }
+    }
+
+    // Helper Methods
+    private fun createRegisterRequest() = RegisterRedcardRequest(
+        cardNumber = "1234-5678",
+        donationDate = LocalDate.now(),
+        hospitalName = "Test Hospital"
+    )
+
+    private fun createRedcard(request: RegisterRedcardRequest) = Redcard(
+        userId = 0L,
+        donationDate = request.donationDate,
+        serialNumber = request.cardNumber,
+        hospitalName = request.hospitalName,
+        redcardStatus = RedcardStatus.AVAILABLE,
+        ownerType = OwnerType.USER
+    )
+}


### PR DESCRIPTION
### 변경 사항
- Redcard 도메인 관련 클래스 및 헌혈증 등록 로직을 코틀린으로 마이그레이션
  - Redcard 엔티티 클래스 코틀린 마이그레이션
  - OwnerType, RedcardStatus Enum 클래스 코틀린 마이그레이션
  - DuplicateSerialNumberException 예외 클래스 코틀린 마이그레이션
  - RegisterRedcardRequest DTO 코틀린 마이그레이션
  - RedcardRepository 코틀린 마이그레이션
  - RedcardService 코틀린 마이그레이션
  
- 헌혈증 등록 기능에 대한 테스트 코드 추가
---

### 관련 이슈
- 이 PR이 해결하는 관련 이슈 번호를 적어 주세요.
#33 

---

### 변경 이유
왜 이러한 변경이 필요했는지 설명해 주세요. 기존 문제나 기능 개선 이유를 포함해 주세요.