### PR TITLE
test: 헌혈증 조회 기능 테스트 추가

### DIFF
--- a/migration/src/main/kotlin/com/redbox/domain/redcard/repository/RedcardRepository.kt
+++ b/migration/src/main/kotlin/com/redbox/domain/redcard/repository/RedcardRepository.kt
@@ -1,9 +1,15 @@
 package com.redbox.domain.redcard.repository
 
 import com.redbox.domain.redcard.entity.Redcard
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.Optional
 
 interface RedcardRepository : JpaRepository<Redcard, Long> {
+
     fun findBySerialNumber(serialNumber: String): Optional<Redcard>
+
+    fun findAllByUserId(userId: Long, pageable: Pageable): Page<Redcard>
+
 }

--- a/migration/src/main/kotlin/com/redbox/domain/redcard/service/RedcardService.kt
+++ b/migration/src/main/kotlin/com/redbox/domain/redcard/service/RedcardService.kt
@@ -7,6 +7,8 @@ import com.redbox.domain.redcard.entity.RedcardStatus
 import com.redbox.domain.redcard.exception.DuplicateSerialNumberException
 import com.redbox.domain.redcard.repository.RedcardRepository
 // import com.redbox.domain.user.service.UserService
+import com.redbox.global.entity.PageResponse
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -37,5 +39,13 @@ class RedcardService(
         )
 
         redcardRepository.save(redcard)
+    }
+
+    fun getRedcards(page: Int, size: Int): PageResponse<Redcard> {
+        val pageable = PageRequest.of(page - 1, size)
+        // val userId = userService.getCurrentUserId() // TODO: UserService 추가 후 수정 필요
+        val userId = 0L // 임시 ID
+        val redcards = redcardRepository.findAllByUserId(userId, pageable)
+        return PageResponse(redcards)
     }
 }

--- a/migration/src/test/kotlin/com/redbox/domain/redcard/service/RedcardServiceTest.kt
+++ b/migration/src/test/kotlin/com/redbox/domain/redcard/service/RedcardServiceTest.kt
@@ -1,12 +1,15 @@
 package com.redbox.domain.redcard.service
 
 import com.redbox.domain.redcard.dto.RegisterRedcardRequest
+import com.redbox.domain.redcard.entity.OwnerType
 import com.redbox.domain.redcard.entity.Redcard
+import com.redbox.domain.redcard.entity.RedcardStatus
 import com.redbox.domain.redcard.repository.RedcardRepository
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
 import java.time.LocalDate
 
 @SpringBootTest
@@ -33,6 +36,23 @@ class RedcardServiceTest {
         // Then
         val savedRedcard: Redcard? = redcardRepository.findBySerialNumber("1234-5678").orElse(null)
         assertNotNull(savedRedcard)
-        println("Saved Redcard: $savedRedcard")
+        println("저장된 Redcard: $savedRedcard")
     }
+
+    @Test
+    fun `유저 아이디가 0인 헌혈증 목록 조회`() {
+        // Given: 기존 데이터베이스에 이미 유저 ID가 0인 헌혈증들이 저장되어 있음
+        val pageRequest = PageRequest.of(0, 5) // 페이지 크기 3
+
+        // When: 유저 ID가 0인 헌혈증 조회
+        val result = redcardService.getRedcards(1, 5) // page=1 (첫 페이지), size=3
+
+        // Then: 반환된 헌혈증들이 모두 userId = 0인지 확인
+        assert(result.content.isNotEmpty()) { "조회된 헌혈증이 없습니다." }
+        assert(result.content.all { it.userId == 0L }) { "조회된 헌혈증 중 userId가 0이 아닌 데이터가 포함되어 있습니다." }
+
+        println("유저 ID가 0인 헌혈증 목록:")
+        result.content.forEach { println(it) } // 각 헌혈증 정보를 개별 출력
+    }
+
 }


### PR DESCRIPTION
### 변경 사항
- 유저 ID가 0인 헌혈증 목록을 페이지네이션 방식으로 조회하는 테스트 코드 작성
- 반환된 결과에서 userId가 0인 데이터만 포함되는지 검증

---

### 관련 이슈
- 이 PR이 해결하는 관련 이슈 번호를 적어 주세요.
  예: #50 

---

### 변경 이유
왜 이러한 변경이 필요했는지 설명해 주세요. 기존 문제나 기능 개선 이유를 포함해 주세요.