### PR TITLE
refactor: JWTUtil 코틀린 마이그레이션 및 userId 타입 변환 로직 추가

### DIFF
--- a/migration/src/main/kotlin/com/redbox/global/auth/util/JWTUtil.kt
+++ b/migration/src/main/kotlin/com/redbox/global/auth/util/JWTUtil.kt
@@ -1,0 +1,90 @@
+package com.redbox.global.auth.util
+
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.util.*
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+
+@Component
+class JWTUtil(
+    @Value("\${jwt_secret}") secret: String
+) {
+    private val secretKey: SecretKey =
+        SecretKeySpec(
+            secret.toByteArray(StandardCharsets.UTF_8),
+            SignatureAlgorithm.HS256.jcaName
+        )
+
+    // userId 추출 메소드
+    fun getUserId(token: String): Long {
+        val claims = parseToken(token)
+        val userId = claims["userId"]
+
+        return when (userId) {
+            is Int -> {
+                userId.toLong() // Integer로 저장된 경우 Long으로 변환
+            }
+            else -> {
+                userId as Long // 원래 Long이면 그대로 반환
+            }
+        }
+    }
+
+
+    // email 추출
+    fun getEmail(token: String): String {
+        val claims = parseToken(token)
+        return claims["email", String::class.java]
+    }
+
+    // role 추출
+    fun getRole(token: String): String {
+        val claims = parseToken(token)
+        return claims["role", String::class.java]
+    }
+
+    // category 추출 (access / refresh 구분)
+    fun getCategory(token: String): String {
+        val claims = parseToken(token)
+        return claims["category", String::class.java]
+    }
+
+    // 토큰 만료 여부 확인
+    fun isExpired(token: String): Boolean {
+        val claims = parseToken(token)
+        return claims.expiration.before(Date())
+    }
+
+    // JWT 생성
+    fun createJwt(
+        category: String,
+        userId: Long,
+        email: String,
+        role: String,
+        expiredMs: Long
+    ): String {
+        return Jwts.builder().apply {
+            claim("category", category)
+            claim("userId", userId)
+            claim("email", email)
+            claim("role", role)
+            setIssuedAt(Date(System.currentTimeMillis()))
+            setExpiration(Date(System.currentTimeMillis() + expiredMs))
+            signWith(secretKey, SignatureAlgorithm.HS256)
+        }.compact()
+    }
+
+    // 토큰 파싱
+    private fun parseToken(token: String): Claims {
+        return Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(token)
+            .body
+    }
+}


### PR DESCRIPTION
### 변경 사항
- JWTUtil을 코틀린으로 마이그레이션
- userId가 Int로 저장된 경우 Long으로 변환하도록 수정
- 기존 Long 타입은 그대로 반환하여 타입 오류 방지

---

### 관련 이슈
- 이 PR이 해결하는 관련 이슈 번호를 적어 주세요.
  #116 

---

### 변경 이유
왜 이러한 변경이 필요했는지 설명해 주세요. 기존 문제나 기능 개선 이유를 포함해 주세요.