### PR TITLE
Refactor/#114 migrate auth refresh token validation

### DIFF
--- a/migration/src/main/kotlin/com/redbox/global/auth/exception/ExpiredRefreshTokenException.kt
+++ b/migration/src/main/kotlin/com/redbox/global/auth/exception/ExpiredRefreshTokenException.kt
@@ -1,0 +1,6 @@
+package com.redbox.global.auth.exception
+
+import com.redbox.global.exception.AuthException
+import com.redbox.global.exception.ErrorCode
+
+class ExpiredRefreshTokenException : AuthException(ErrorCode.EXPIRED_TOKEN)

--- a/migration/src/main/kotlin/com/redbox/global/auth/exception/InvalidTokenCategoryException.kt
+++ b/migration/src/main/kotlin/com/redbox/global/auth/exception/InvalidTokenCategoryException.kt
@@ -1,0 +1,6 @@
+package com.redbox.global.auth.exception
+
+import com.redbox.global.exception.AuthException
+import com.redbox.global.exception.ErrorCode
+
+class InvalidTokenCategoryException : AuthException(ErrorCode.INVALID_TOKEN_CATEGORY)

--- a/migration/src/main/kotlin/com/redbox/global/auth/exception/RefreshTokenNotFoundException.kt
+++ b/migration/src/main/kotlin/com/redbox/global/auth/exception/RefreshTokenNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.redbox.global.auth.exception
+
+import com.redbox.global.exception.AuthException
+import com.redbox.global.exception.ErrorCode
+
+class RefreshTokenNotFoundException : AuthException(ErrorCode.TOKEN_NOT_FOUND)

--- a/migration/src/main/kotlin/com/redbox/global/auth/service/ReissueService.kt
+++ b/migration/src/main/kotlin/com/redbox/global/auth/service/ReissueService.kt
@@ -1,0 +1,27 @@
+package com.redbox.global.auth.service
+
+import com.redbox.global.auth.exception.ExpiredRefreshTokenException
+import com.redbox.global.auth.exception.InvalidTokenCategoryException
+import com.redbox.global.auth.exception.RefreshTokenNotFoundException
+import com.redbox.global.auth.util.JWTUtil
+import org.springframework.stereotype.Service
+
+@Service
+class ReissueService(
+    private val jwtUtil: JWTUtil,
+    private val refreshTokenService: RefreshTokenService
+) {
+
+    // Refresh Token 유효성 검사
+    fun validateRefreshToken(refreshToken: String?) {
+        require(!refreshToken.isNullOrBlank()) { throw RefreshTokenNotFoundException() }
+
+        refreshToken.apply {
+            when {
+                jwtUtil.isExpired(this) -> throw ExpiredRefreshTokenException()
+                jwtUtil.getCategory(this) != "refresh" -> throw InvalidTokenCategoryException()
+                !refreshTokenService.existsByRefreshToken(this) -> throw RefreshTokenNotFoundException()
+            }
+        }
+    }
+}

--- a/migration/src/main/kotlin/com/redbox/global/exception/ErrorCode.kt
+++ b/migration/src/main/kotlin/com/redbox/global/exception/ErrorCode.kt
@@ -68,6 +68,7 @@ enum class ErrorCode(
     TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "Refresh 토큰이 존재하지 않습니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    INVALID_TOKEN_CATEGORY(HttpStatus.BAD_REQUEST, "잘못된 토큰 카테고리입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
 
     // 레드박스


### PR DESCRIPTION
### 변경 사항
ReissueService의 Refresh Token 유효성 검사 기능을 Kotlin으로 마이그레이션
커스텀 예외 Kotlin으로 마이그레이션
InvalidTokenCategoryException 추가

---

### 관련 이슈
- 이 PR이 해결하는 관련 이슈 번호를 적어 주세요.
  #114 
