### PR TITLE
Refactor/#137 auth refresh token based reissue migration

### DIFF
--- a/migration/src/main/kotlin/com/redbox/global/auth/controller/ReissueController.kt
+++ b/migration/src/main/kotlin/com/redbox/global/auth/controller/ReissueController.kt
@@ -1,0 +1,40 @@
+package com.redbox.domain.auth.controller
+
+import com.redbox.global.auth.service.ReissueService
+import com.redbox.global.exception.AuthException
+import com.redbox.global.exception.ErrorResponse
+import com.redbox.global.util.error.ErrorResponseUtil
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth")
+class ReissueController(
+    private val reissueService: ReissueService
+) {
+
+    @PostMapping("/reissue")
+    fun reissue(
+        @RequestHeader("Refresh-Token") refreshToken: String,
+        response: HttpServletResponse
+    ): ResponseEntity<ErrorResponse> {
+        return try {
+            // 토큰 재발급
+            val newAccessToken = reissueService.reissueAccessToken(refreshToken)
+            val newRefreshToken = reissueService.reissueRefreshToken(refreshToken)
+
+            // 응답에 토큰 추가
+            response.setHeader("Authorization", "Bearer $newAccessToken") // 새 Access Token
+            response.setHeader("Refresh-Token", newRefreshToken)         // 새 Refresh Token
+
+            // 성공 응답에 맞는 객체를 생성
+            ResponseEntity.ok(ErrorResponse("토큰 재발급 성공", "SUCCESS"))
+        } catch (e: AuthException) {
+            ErrorResponseUtil.createErrorResponse(e.errorCode) // 그대로 반환
+        }
+    }
+}

--- a/migration/src/main/kotlin/com/redbox/global/auth/service/ReissueService.kt
+++ b/migration/src/main/kotlin/com/redbox/global/auth/service/ReissueService.kt
@@ -11,6 +11,33 @@ class ReissueService(
     private val jwtUtil: JWTUtil,
     private val refreshTokenService: RefreshTokenService
 ) {
+    fun reissueAccessToken(refreshToken: String): String {
+        validateRefreshToken(refreshToken)
+
+        val userId = jwtUtil.getUserId(refreshToken)
+        val email = jwtUtil.getEmail(refreshToken)
+        val role = jwtUtil.getRole(refreshToken)
+
+        // Access Token 생성 (유효 시간: 10분)
+        return jwtUtil.createJwt("access", userId, email, role, 600_000L)
+    }
+
+    fun reissueRefreshToken(refreshToken: String): String {
+        validateRefreshToken(refreshToken)
+
+        val userId = jwtUtil.getUserId(refreshToken)
+        val email = jwtUtil.getEmail(refreshToken)
+        val role = jwtUtil.getRole(refreshToken)
+
+        // 새 Refresh Token 생성 (유효 시간: 1일)
+        val newRefreshToken = jwtUtil.createJwt("refresh", userId, email, role, 86_400_000L)
+
+        // 기존 Refresh Token 삭제 후 새로운 Refresh Token 저장
+        refreshTokenService.deleteRefreshToken(refreshToken)
+        refreshTokenService.saveRefreshToken(email, newRefreshToken, 86_400_000L)
+
+        return newRefreshToken
+    }
 
     // Refresh Token 유효성 검사
     fun validateRefreshToken(refreshToken: String?) {

--- a/migration/src/main/kotlin/com/redbox/global/config/SecurityConfig.kt
+++ b/migration/src/main/kotlin/com/redbox/global/config/SecurityConfig.kt
@@ -33,7 +33,7 @@ class SecurityConfig(
             .csrf { it.disable() }
             .authorizeHttpRequests { auth ->
                 auth
-                    .requestMatchers("/auth/login", "/auth/signup", "/auth/logout", "/auth/email/**").permitAll()
+                    .requestMatchers("/auth/**").permitAll()
                     .anyRequest().authenticated() // ✅ 나머지는 인증 필요
             }
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter::class.java)


### PR DESCRIPTION
### 변경 사항
Refresh Token 기반 토큰 재발급 기능을 마이그레이션

- ReissueController 및 ReissueService 코드를 Kotlin으로 변환
- Refresh Token 유효성 검증 및 Redis와의 상호작용 구현
- 새로 발급된 Access Token과 Refresh Token을 HTTP 헤더로 반환
- SecurityConfig에 "/auth/**" 경로 인증 예외 추가 및 JWTFilter 연동

---

### 관련 이슈
- 이 PR이 해결하는 관련 이슈 번호를 적어 주세요.
  #137
